### PR TITLE
feat: Show git branch in project picker

### DIFF
--- a/lua/kitty/commands.lua
+++ b/lua/kitty/commands.lua
@@ -24,9 +24,9 @@ function M.send_command(args)
       args
     ),
   })
-  
+
   local raw_results = job:sync()
-  
+
   if job.code ~= 0 then
     log.error('Kitty command failed: ', args, 'Code: ', job.code)
     vim.notify('kitty-projects: Command failed - is remote control enabled?', vim.log.levels.ERROR)
@@ -51,11 +51,11 @@ end
 
 function M.get_current_tab()
   local all_windows = M.list_windows()
-  
+
   if not all_windows then
     return nil
   end
-  
+
   for _, os_window in ipairs(all_windows) do
     if os_window.tabs then
       for _, tab in ipairs(os_window.tabs) do
@@ -65,7 +65,7 @@ function M.get_current_tab()
       end
     end
   end
-  
+
   return nil
 end
 

--- a/lua/kitty/projects.lua
+++ b/lua/kitty/projects.lua
@@ -29,6 +29,7 @@ local function map_paths_to_projects(project_paths)
         id = (active_window or {}).id,
         name = basename,
         path = path,
+        branch = utils.get_git_branch(path),
         is_focused = (active_window or {}).is_focused or false,
         was_focused = previous_project_name == basename,
         open = active_window ~= nil

--- a/lua/kitty/utils.lua
+++ b/lua/kitty/utils.lua
@@ -42,6 +42,18 @@ function M.list_sub_directories(parent_dir, exclude_hidden)
   }):sync()
 end
 
+function M.get_git_branch(path)
+  local result = Job:new({
+    command = 'git',
+    args = { '-C', path, 'rev-parse', '--abbrev-ref', 'HEAD' },
+  }):sync()
+
+  if result and result[1] then
+    return result[1]
+  end
+  return nil
+end
+
 function M.list_all_sub_directories(path_configs)
   local jobs = {}
   local all_paths = {}

--- a/lua/snacks/_extensions/kitty.lua
+++ b/lua/snacks/_extensions/kitty.lua
@@ -7,11 +7,14 @@ function M.projects(opts)
 
   local projects = kitty_projects.list()
 
-  -- Calculate max project name width for alignment
   local max_name_width = 0
+  local max_branch_width = 0
   for _, project in ipairs(projects) do
     if #project.name > max_name_width then
       max_name_width = #project.name
+    end
+    if project.branch and #project.branch > max_branch_width then
+      max_branch_width = #project.branch
     end
   end
 
@@ -35,7 +38,9 @@ function M.projects(opts)
       project = project,
       buf = '',
       path = vim.fn.fnamemodify(project.path, ':~'),
-      max_name_width = max_name_width
+      branch = project.branch,
+      max_name_width = max_name_width,
+      max_branch_width = max_branch_width
     })
   end
 
@@ -46,11 +51,13 @@ function M.projects(opts)
     format = function(item)
       local indicator_col = string.format("%-2s", item.indicator)
       local name_col = string.format("%-" .. item.max_name_width .. "s", item.text)
+      local branch_col = item.branch and string.format("%-" .. item.max_branch_width .. "s", item.branch) or string.rep(" ", item.max_branch_width)
       local path_col = item.path
 
       return {
         { indicator_col },
         { " " .. name_col },
+        { " " .. branch_col, 'String' },
         { " " .. path_col, 'Comment' }
       }
     end,

--- a/lua/telescope/_extensions/kitty.lua
+++ b/lua/telescope/_extensions/kitty.lua
@@ -14,10 +14,14 @@ local list_kitty_projects = function(opts)
   local make_finder = function()
     local projects = kitty_projects.list()
 
-    local max_width = 0
+    local max_name_width = 0
+    local max_branch_width = 0
     for _, project in ipairs(projects) do
-      if #project.name > max_width then
-        max_width = #project.name
+      if #project.name > max_name_width then
+        max_name_width = #project.name
+      end
+      if project.branch and #project.branch > max_branch_width then
+        max_branch_width = #project.branch
       end
     end
 
@@ -25,7 +29,8 @@ local list_kitty_projects = function(opts)
       separator = " ",
       items = {
         { width = 2 },
-        { width = max_width },
+        { width = max_name_width },
+        { width = max_branch_width },
         { remaining = true },
       },
     }
@@ -50,6 +55,7 @@ local list_kitty_projects = function(opts)
               return displayer({
                 indicator,
                 project.name,
+                { project.branch or '', 'TelescopeResultsIdentifier' },
                 { vim.fn.fnamemodify(project.path, ':~'), 'TelescopeResultsComment' }
               })
             end


### PR DESCRIPTION
## Summary
- Add `get_git_branch` utility function to fetch current branch for a path
- Include branch information in project data when listing projects
- Display git branch column in both Snacks and Telescope pickers

## Test plan
- [ ] Open project picker with `:KittyProjects`
- [ ] Verify git branch is displayed for each project
- [ ] Verify non-git directories show empty branch column
- [ ] Test with both Snacks and Telescope pickers